### PR TITLE
mapping position support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'README.md'
   push:
+    branches:
+      - master
     paths-ignore:
       - 'README.md'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - 'README.md'
   push:
-    branches:
-      - master
     paths-ignore:
       - 'README.md'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         terraform:
           - '1.5.*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        max-parallel: 1
         terraform:
           - '1.5.*'
           - '1.6.*'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'README.md'
   push:
+    branches:
+      - master
     paths-ignore:
       - 'README.md'
 
@@ -57,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
+        max-parallel: 1
         terraform:
           - '1.5.*'
           - '1.6.*'

--- a/internal/provider/onelogin_mapping.go
+++ b/internal/provider/onelogin_mapping.go
@@ -34,11 +34,13 @@ type oneloginMappingResource struct {
 	client *onelogin.Client
 }
 
+// Position and Enabled are set via the mapping_order resource.
+// This is is necessary due to how position affects multiple resources
+// and must be changed in conjunction with enabled.
 type oneloginMapping struct {
 	ID         types.Int64  `tfsdk:"id"`
 	Name       types.String `tfsdk:"name"`
 	Match      types.String `tfsdk:"match"`
-	Enabled    types.Bool   `tfsdk:"enabled"`
 	Conditions types.List   `tfsdk:"conditions"`
 	Actions    types.List   `tfsdk:"actions"`
 }
@@ -90,9 +92,6 @@ func (d *oneloginMappingResource) Schema(ctx context.Context, req resource.Schem
 			},
 			"match": schema.StringAttribute{
 				Required: true,
-			},
-			"enabled": schema.BoolAttribute{
-				Computed: true,
 			},
 
 			// Condition  sources, operators and values can be discovered with these endpoints
@@ -299,10 +298,9 @@ func (d *oneloginMappingResource) readToState(ctx context.Context, state *onelog
 
 func (state *oneloginMapping) toNativeMapping(ctx context.Context) *onelogin.Mapping {
 	native := &onelogin.Mapping{
-		ID:      state.ID.ValueInt64(),
-		Name:    state.Name.ValueString(),
-		Match:   state.Match.ValueString(),
-		Enabled: state.Enabled.ValueBool(),
+		ID:    state.ID.ValueInt64(),
+		Name:  state.Name.ValueString(),
+		Match: state.Match.ValueString(),
 	}
 
 	conditions := []oneloginMappingCondition{}
@@ -331,10 +329,9 @@ func (state *oneloginMapping) toNativeMapping(ctx context.Context) *onelogin.Map
 
 func mappingToState(ctx context.Context, mapping *onelogin.Mapping) (*oneloginMapping, diag.Diagnostics) {
 	state := &oneloginMapping{
-		ID:      types.Int64Value(mapping.ID),
-		Name:    types.StringValue(mapping.Name),
-		Match:   types.StringValue(mapping.Match),
-		Enabled: types.BoolValue(mapping.Enabled),
+		ID:    types.Int64Value(mapping.ID),
+		Name:  types.StringValue(mapping.Name),
+		Match: types.StringValue(mapping.Match),
 	}
 
 	diags := diag.Diagnostics{}

--- a/internal/provider/onelogin_mapping_order.go
+++ b/internal/provider/onelogin_mapping_order.go
@@ -34,12 +34,6 @@ type oneloginMappingOrder struct {
 	Disabled []int64 `tfsdk:"disabled"`
 }
 
-type oneloginNativeMappingOrder []struct {
-	ID       int64 `json:"id"`
-	Enabled  bool  `json:"enabled"`
-	Position int64 `json:"position"`
-}
-
 func (r *oneloginMappingOrderResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_mapping_order"
 }
@@ -146,7 +140,7 @@ func (r *oneloginMappingOrderResource) Update(ctx context.Context, req resource.
 	}
 
 	// Build maps of enabled and disabled.
-	// Validate that ids are not duplicated accross both lists
+	// Validate that ids are not duplicated across both lists
 	allInPlan := map[int64]bool{}
 	enabledInPlan := map[int64]bool{}
 	disabledInPlan := map[int64]bool{}
@@ -184,7 +178,7 @@ func (r *oneloginMappingOrderResource) Update(ctx context.Context, req resource.
 			var updateResp struct {
 				ID int64 `json:"id"`
 			}
-			err := r.client.ExecRequest(&onelogin.Request{
+			err := r.client.ExecRequestCtx(ctx, &onelogin.Request{
 				Method:    onelogin.MethodPut,
 				Path:      fmt.Sprintf("%s/%d", onelogin.PathMappings, targetID),
 				Body:      m,
@@ -210,7 +204,7 @@ func (r *oneloginMappingOrderResource) Update(ctx context.Context, req resource.
 			var updateResp struct {
 				ID int64 `json:"id"`
 			}
-			err := r.client.ExecRequest(&onelogin.Request{
+			err := r.client.ExecRequestCtx(ctx, &onelogin.Request{
 				Method:    onelogin.MethodPut,
 				Path:      fmt.Sprintf("%s/%d", onelogin.PathMappings, targetID),
 				Body:      m,
@@ -225,7 +219,7 @@ func (r *oneloginMappingOrderResource) Update(ctx context.Context, req resource.
 
 	// Sort enabled mappings
 	var sortResp []int64
-	err := r.client.ExecRequest(&onelogin.Request{
+	err := r.client.ExecRequestCtx(ctx, &onelogin.Request{
 		Method:    onelogin.MethodPut,
 		Path:      onelogin.PathMappingsSort,
 		Body:      state.Enabled,
@@ -298,7 +292,7 @@ func (r *oneloginMappingOrderResource) getEnabled(ctx context.Context) ([]onelog
 
 	// Get enabled
 	var enabled []onelogin.Mapping
-	err := r.client.ExecRequest(&onelogin.Request{
+	err := r.client.ExecRequestCtx(ctx, &onelogin.Request{
 		Method:    onelogin.MethodGet,
 		Path:      onelogin.PathMappings,
 		RespModel: &enabled,
@@ -338,7 +332,7 @@ func (r *oneloginMappingOrderResource) getDisabled(ctx context.Context) ([]onelo
 
 	// Get disabled
 	var disabled []onelogin.Mapping
-	err := r.client.ExecRequest(&onelogin.Request{
+	err := r.client.ExecRequestCtx(ctx, &onelogin.Request{
 		Method:    onelogin.MethodGet,
 		Path:      onelogin.PathMappings,
 		RespModel: &disabled,

--- a/internal/provider/onelogin_mapping_order.go
+++ b/internal/provider/onelogin_mapping_order.go
@@ -1,0 +1,355 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/ghaggin/terraform-provider-onelogin/onelogin"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var (
+	_ resource.Resource = &oneloginMappingOrderResource{}
+)
+
+func NewOneLoginMappingOrderResource(client *onelogin.Client) newResourceFunc {
+	return func() resource.Resource {
+		return &oneloginMappingOrderResource{
+			client: client,
+		}
+	}
+}
+
+type oneloginMappingOrderResource struct {
+	client *onelogin.Client
+}
+
+type oneloginMappingOrder struct {
+	Enabled  []int64 `tfsdk:"enabled"`
+	Disabled []int64 `tfsdk:"disabled"`
+}
+
+type oneloginNativeMappingOrder []struct {
+	ID       int64 `json:"id"`
+	Enabled  bool  `json:"enabled"`
+	Position int64 `json:"position"`
+}
+
+func (r *oneloginMappingOrderResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_mapping_order"
+}
+
+func (r *oneloginMappingOrderResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"enabled": schema.ListAttribute{
+				ElementType: types.Int64Type,
+				Required:    true,
+			},
+			"disabled": schema.ListAttribute{
+				ElementType: types.Int64Type,
+				Required:    true,
+			},
+		},
+	}
+}
+
+// Create reconciles the terraform config vs the state of Onelogin.
+// No Onelogin resources are created or destroyed during this operation
+// and config writers should create the config to match the state of Onelogin.
+// Modifications to resources in OneLogin should only be made through the update operation.
+func (r *oneloginMappingOrderResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var state oneloginMappingOrder
+	diags := req.Plan.Get(ctx, &state)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	// Reconcile enabled and disabled against Onelogin
+	enabled, diags := r.getEnabled(ctx)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	disabled, diags := r.getDisabled(ctx)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	if len(enabled) != len(state.Enabled) {
+		resp.Diagnostics.AddError("enabled length different in config and onelogin", "Please update the enabled mappings to match onelogin, including position")
+		return
+	}
+
+	if len(disabled) != len(state.Disabled) {
+		resp.Diagnostics.AddError("disabled length different in config and onelogin", "Please update the disabled mappings to match onelogin")
+	}
+
+	if diags.HasError() {
+		return
+	}
+
+	// Reconcile enabled
+	for i, id := range state.Enabled {
+		if enabled[i].ID != id {
+			resp.Diagnostics.AddError("enabled mappings do not match onelogin", "Please update the enabled mappings to match onelogin, including position")
+			return
+		}
+	}
+
+	// Reconcile disabled
+	for i, id := range state.Disabled {
+		if disabled[i].ID != id {
+			resp.Diagnostics.AddError("disabled mappings do not match onelogin", "Please update the disabled mappings to match onelogin")
+			return
+		}
+	}
+
+	// Set state
+	diags = resp.State.Set(ctx, &state)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+}
+
+func (r *oneloginMappingOrderResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.readToState(ctx, &resp.State)
+}
+
+func (r *oneloginMappingOrderResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var state oneloginMappingOrder
+	diags := req.Plan.Get(ctx, &state)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	enabled, diags := r.getEnabled(ctx)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	disabled, diags := r.getDisabled(ctx)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+
+	// Build maps of enabled and disabled.
+	// Validate that ids are not duplicated accross both lists
+	allInPlan := map[int64]bool{}
+	enabledInPlan := map[int64]bool{}
+	disabledInPlan := map[int64]bool{}
+
+	for _, id := range state.Enabled {
+		enabledInPlan[id] = true
+		_, ok := allInPlan[id]
+		if ok {
+			resp.Diagnostics.AddError("duplicate id in enabled", "Please ensure all IDs are only added to the mapping_order once")
+			return
+		}
+		allInPlan[id] = true
+	}
+
+	for _, id := range state.Disabled {
+		disabledInPlan[id] = true
+		_, ok := allInPlan[id]
+		if ok {
+			resp.Diagnostics.AddError("duplicate id in enabled", "Please ensure all IDs are only added to the mapping_order once")
+			return
+		}
+		allInPlan[id] = true
+	}
+
+	// Find any currently enabled mappings that should be disabled
+	// and disable them
+	for _, m := range enabled {
+		_, ok := disabledInPlan[m.ID]
+		if ok {
+			targetID := m.ID
+			m.ID = 0
+			m.Position = nil
+			m.Enabled = false
+
+			var updateResp struct {
+				ID int64 `json:"id"`
+			}
+			err := r.client.ExecRequest(&onelogin.Request{
+				Method:    onelogin.MethodPut,
+				Path:      fmt.Sprintf("%s/%d", onelogin.PathMappings, targetID),
+				Body:      m,
+				RespModel: &updateResp,
+			})
+			if err != nil || updateResp.ID != targetID {
+				resp.Diagnostics.AddError("failed to disable mapping", fmt.Sprintf("err: %v\nresp id: %v\ntarget id: %v", err.Error(), updateResp.ID, targetID))
+				return
+			}
+		}
+	}
+
+	// Find any currently disabled mappings that should be enabled
+	// Enable them with null position and sort them in the next step
+	for _, m := range disabled {
+		_, ok := enabledInPlan[m.ID]
+		if ok {
+			targetID := m.ID
+			m.ID = 0
+			m.Position = nil
+			m.Enabled = true
+
+			var updateResp struct {
+				ID int64 `json:"id"`
+			}
+			err := r.client.ExecRequest(&onelogin.Request{
+				Method:    onelogin.MethodPut,
+				Path:      fmt.Sprintf("%s/%d", onelogin.PathMappings, targetID),
+				Body:      m,
+				RespModel: &updateResp,
+			})
+			if err != nil || updateResp.ID != targetID {
+				resp.Diagnostics.AddError("failed to enable mapping", fmt.Sprintf("err: %v\nresp id: %v\ntarget id: %v", err.Error(), updateResp.ID, targetID))
+				return
+			}
+		}
+	}
+
+	// Sort enabled mappings
+	var sortResp []int64
+	err := r.client.ExecRequest(&onelogin.Request{
+		Method:    onelogin.MethodPut,
+		Path:      onelogin.PathMappingsSort,
+		Body:      state.Enabled,
+		RespModel: &sortResp,
+	})
+
+	if err != nil {
+		resp.Diagnostics.AddError("failed to sort mappings", err.Error())
+		return
+	}
+
+	// Reconcile response vs state
+	if len(sortResp) != len(state.Enabled) {
+		resp.Diagnostics.AddError("enexpected failed to sort mappings", "sort response is a different length from the state enabled list")
+		return
+	}
+
+	for i, id := range sortResp {
+		if id != state.Enabled[i] {
+			resp.Diagnostics.AddError("failed to sort mappings", "sort response does not match state enabled list")
+			return
+		}
+	}
+
+	// Set state
+	diags = resp.State.Set(ctx, &state)
+	if diags.HasError() {
+		resp.Diagnostics = diags
+		return
+	}
+}
+
+func (r *oneloginMappingOrderResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// Noop, nothing to delete in onelogin
+}
+
+func (r *oneloginMappingOrderResource) readToState(ctx context.Context, respState *tfsdk.State) diag.Diagnostics {
+	// Get enabled
+	enabled, diags := r.getEnabled(ctx)
+	if diags.HasError() {
+		return diags
+	}
+
+	enabledIDs := make([]int64, len(enabled))
+	for i, m := range enabled {
+		enabledIDs[i] = m.ID
+	}
+
+	// Get disabled
+	disabled, diags := r.getDisabled(ctx)
+	if diags.HasError() {
+		return diags
+	}
+
+	disabledIDs := make([]int64, len(disabled))
+	for i, m := range disabled {
+		disabledIDs[i] = m.ID
+	}
+
+	// Convert to state
+	var state oneloginMappingOrder
+	state.Enabled = enabledIDs
+	state.Disabled = disabledIDs
+
+	return respState.Set(ctx, &state)
+}
+
+func (r *oneloginMappingOrderResource) getEnabled(ctx context.Context) ([]onelogin.Mapping, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	// Get enabled
+	var enabled []onelogin.Mapping
+	err := r.client.ExecRequest(&onelogin.Request{
+		Method:    onelogin.MethodGet,
+		Path:      onelogin.PathMappings,
+		RespModel: &enabled,
+	})
+	if err != nil {
+		diags.AddError("failed to get enabled mappings: ", err.Error())
+		return nil, diags
+	}
+
+	// Ensure no enabled mappings have a null position
+	for _, m := range enabled {
+		if m.Position == nil {
+			diags.AddError("enabled mappings cannot have a null position", "Please update the enabled mappings to include a position")
+			return nil, diags
+		}
+	}
+
+	// Ensure enabled is sorted by position
+	sort.Slice(enabled, func(i, j int) bool {
+		return *enabled[i].Position < *enabled[j].Position
+	})
+
+	// Ensure position value is as expected
+	// Assumptions made in this provider rely on this numbering
+	for i, m := range enabled {
+		if *m.Position != int64(i+1) {
+			diags.AddError("mapping positions are not linearly increasing starting at 1", "Assumptions made in this provider rely on this numbering")
+			return nil, diags
+		}
+	}
+
+	return enabled, nil
+}
+
+func (r *oneloginMappingOrderResource) getDisabled(ctx context.Context) ([]onelogin.Mapping, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	// Get disabled
+	var disabled []onelogin.Mapping
+	err := r.client.ExecRequest(&onelogin.Request{
+		Method:    onelogin.MethodGet,
+		Path:      onelogin.PathMappings,
+		RespModel: &disabled,
+		QueryParams: onelogin.QueryParams{
+			"enabled": "false",
+		},
+	})
+	if err != nil {
+		diags.AddError("failed to get disabled mappings: ", err.Error())
+		return nil, diags
+	}
+
+	return disabled, nil
+}

--- a/internal/provider/onelogin_mapping_order_test.go
+++ b/internal/provider/onelogin_mapping_order_test.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ghaggin/terraform-provider-onelogin/onelogin"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func (s *providerTestSuite) TestMappingOrder() {
+	var resp []struct {
+		ID       int64 `json:"id"`
+		Enabled  bool  `json:"enabled"`
+		Position int64 `json:"position"`
+	}
+
+	err := s.client.ExecRequest(&onelogin.Request{
+		Method:    onelogin.MethodGet,
+		Path:      onelogin.PathMappings,
+		RespModel: &resp,
+		// QueryParams: onelogin.QueryParams{
+		// 	"enabled": "false",
+		// },
+	})
+	s.Require().NoError(err)
+
+	sort.Slice(resp, func(i, j int) bool {
+		return resp[i].Position < resp[j].Position
+	})
+
+	for i, m := range resp {
+		s.Equal(int64(i+1), m.Position)
+	}
+}
+
+func (s *providerTestSuite) TestAccResourceMappingOrderIndependent() {
+	ctx := context.Background()
+
+	mappingOrderResource := oneloginMappingOrderResource{
+		client: s.client,
+	}
+
+	enabled, diags := mappingOrderResource.getEnabled(ctx)
+	s.Require().Nil(diags, diags.Errors())
+
+	disabled, diags := mappingOrderResource.getDisabled(ctx)
+	s.Require().Nil(diags, diags.Errors())
+
+	enabledIDs := make([]string, len(enabled))
+	for i, m := range enabled {
+		enabledIDs[i] = strconv.Itoa(int(m.ID))
+	}
+
+	disabledIDs := make([]string, len(disabled))
+	for i, m := range disabled {
+		disabledIDs[i] = strconv.Itoa(int(m.ID))
+	}
+
+	enabledStr := "[" + strings.Join(enabledIDs, ",") + "]"
+	disabledStr := "[" + strings.Join(disabledIDs, ",") + "]"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: s.providerConfig + fmt.Sprintf(`
+					resource "onelogin_mapping_order" "test" {
+						enabled = %v
+						disabled = %v
+					}
+				`, enabledStr, disabledStr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled))),
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled))),
+				),
+			},
+		},
+	})
+}
+
+func (s *providerTestSuite) TestAccResourceMappingOrderIntegrated() {
+	ctx := context.Background()
+
+	mappingOrderResource := oneloginMappingOrderResource{
+		client: s.client,
+	}
+
+	enabled, diags := mappingOrderResource.getEnabled(ctx)
+	s.Require().Nil(diags, diags.Errors())
+
+	disabled, diags := mappingOrderResource.getDisabled(ctx)
+	s.Require().Nil(diags, diags.Errors())
+
+	enabledIDs := make([]string, len(enabled))
+	for i, m := range enabled {
+		enabledIDs[i] = strconv.Itoa(int(m.ID))
+	}
+
+	disabledIDs := make([]string, len(disabled))
+	for i, m := range disabled {
+		disabledIDs[i] = strconv.Itoa(int(m.ID))
+	}
+
+	enabledStr := "[" + strings.Join(enabledIDs, ",") + "]"
+	enabledStrWithNewResource := "[" + strings.Join(enabledIDs, ",") + ",onelogin_mapping.test.id" + "]"
+	disabledStr := "[" + strings.Join(disabledIDs, ",") + "]"
+	disabledStrWithNewResource := "[" + strings.Join(disabledIDs, ",") + ",onelogin_mapping.test.id" + "]"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: s.providerConfig + fmt.Sprintf(`
+					resource "onelogin_mapping_order" "test" {
+						enabled = %v
+						disabled = %v
+					}
+
+					resource "onelogin_mapping" "test" {
+						name = "test_mapping"
+						match = "all"
+						conditions = [
+							{
+								source = "last_login"
+								operator = ">"
+								value = "90"
+							}
+						]
+						actions = [
+							{
+								action = "set_status"
+								value = ["2"]
+							}
+						]
+					}
+				`, enabledStr, disabledStrWithNewResource),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled))),
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled)+1)),
+					resource.TestCheckResourceAttr("onelogin_mapping.test", "enabled", "false"),
+				),
+			},
+			{
+				Config: s.providerConfig + fmt.Sprintf(`
+					resource "onelogin_mapping_order" "test" {
+						enabled = %v
+						disabled = %v
+					}
+
+					resource "onelogin_mapping" "test" {
+						name = "test_mapping"
+						match = "all"
+						conditions = [
+							{
+								source = "last_login"
+								operator = ">"
+								value = "90"
+							}
+						]
+						actions = [
+							{
+								action = "set_status"
+								value = ["2"]
+							}
+						]
+					}
+				`, enabledStrWithNewResource, disabledStr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled)+1)),
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled))),
+					resource.TestCheckResourceAttr("onelogin_mapping.test", "enabled", "true"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/onelogin_mapping_order_test.go
+++ b/internal/provider/onelogin_mapping_order_test.go
@@ -141,7 +141,6 @@ func (s *providerTestSuite) TestAccResourceMappingOrderIntegrated() {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled))),
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled)+1)),
-					resource.TestCheckResourceAttr("onelogin_mapping.test", "enabled", "false"),
 				),
 			},
 			{
@@ -172,7 +171,6 @@ func (s *providerTestSuite) TestAccResourceMappingOrderIntegrated() {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled)+1)),
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled))),
-					resource.TestCheckResourceAttr("onelogin_mapping.test", "enabled", "true"),
 				),
 			},
 		},

--- a/internal/provider/onelogin_mapping_test.go
+++ b/internal/provider/onelogin_mapping_test.go
@@ -104,7 +104,6 @@ func (s *providerTestSuite) TestAccResourceMapping() {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "name", name),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "match", "all"),
-					resource.TestCheckResourceAttr("onelogin_mapping.test", "enabled", "false"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "conditions.0.source", "last_login"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "conditions.0.operator", ">"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "conditions.0.value", "90"),
@@ -139,7 +138,6 @@ func (s *providerTestSuite) TestAccResourceMapping() {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "name", name+"_1234"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "match", "any"),
-					resource.TestCheckResourceAttr("onelogin_mapping.test", "enabled", "false"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "conditions.0.source", "has_role"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "conditions.0.operator", "ri"),
 					resource.TestCheckResourceAttrSet("onelogin_mapping.test", "conditions.0.value"),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -116,6 +116,7 @@ func (p *oneloginProvider) Resources(ctx context.Context) []func() resource.Reso
 		NewOneLoginAppResource(&p.client),
 		NewOneLoginUserResource(&p.client),
 		NewOneLoginMappingResource(&p.client),
+		NewOneLoginMappingOrderResource(&p.client),
 	}
 }
 

--- a/onelogin/client.go
+++ b/onelogin/client.go
@@ -46,10 +46,11 @@ const (
 	MethodPut    method = http.MethodPut
 	MethodDelete method = http.MethodDelete
 
-	PathApps     = "/api/2/apps"
-	PathRoles    = "/api/2/roles"
-	PathUsers    = "/api/2/users"
-	PathMappings = "/api/2/mappings"
+	PathApps         = "/api/2/apps"
+	PathRoles        = "/api/2/roles"
+	PathUsers        = "/api/2/users"
+	PathMappings     = "/api/2/mappings"
+	PathMappingsSort = "/api/2/mappings/sort"
 )
 
 type Request struct {


### PR DESCRIPTION
Add mapping_order resource which manages the enable and position attributes for all mappings.  All mappings in the remote server should be managed by this resource.

Mapping position is accomplished by creating a higher order resource which manages all the mapping positions.  Mapping positions need to be managed in a single resource since changes in the position of one mapping cause a side effect where other mapping's positions are are updated.   