### PR TITLE
implement managed role users

### DIFF
--- a/internal/provider/onelogin_role.go
+++ b/internal/provider/onelogin_role.go
@@ -75,7 +75,6 @@ func (d *oneloginRoleResource) Schema(ctx context.Context, req resource.SchemaRe
 			"users": schema.ListAttribute{
 				ElementType: types.Int64Type,
 				Optional:    true,
-				Computed:    true,
 			},
 
 			// Note: attribute local to terraform objects
@@ -96,12 +95,18 @@ func (d *oneloginRoleResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	newRole, diags := state.toNative(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	var role onelogin.Role
 	err := d.client.ExecRequest(&onelogin.Request{
 		Context:   ctx,
 		Method:    onelogin.MethodPost,
 		Path:      onelogin.PathRoles,
-		Body:      state.toNative(ctx),
+		Body:      newRole,
 		RespModel: &role,
 	})
 	if err != nil {
@@ -112,7 +117,7 @@ func (d *oneloginRoleResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	newState, diags := d.read(ctx, role.ID)
+	newState, diags := d.read(ctx, role.ID, state.Users)
 	if diags.HasError() {
 		return
 	}
@@ -134,7 +139,7 @@ func (d *oneloginRoleResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	newState, diags := d.read(ctx, state.ID.ValueInt64())
+	newState, diags := d.read(ctx, state.ID.ValueInt64(), state.Users)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -150,21 +155,30 @@ func (d *oneloginRoleResource) Read(ctx context.Context, req resource.ReadReques
 }
 
 func (d *oneloginRoleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var state oneloginRole
-	diags := req.Plan.Get(ctx, &state)
+	var plan oneloginRole
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	body := state.toNative(ctx)
+	body, diags := plan.toNative(ctx)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	body.ID = 0 // zero out id to omit from the json body
+
+	// Omit users from the full update.
+	// Update users individually based on add/remove from plan
+	body.Users = nil
 
 	var role onelogin.Role
 	err := d.client.ExecRequest(&onelogin.Request{
 		Context:   ctx,
 		Method:    onelogin.MethodPut,
-		Path:      fmt.Sprintf("%s/%v", onelogin.PathRoles, state.ID.ValueInt64()),
+		Path:      fmt.Sprintf("%s/%v", onelogin.PathRoles, plan.ID.ValueInt64()),
 		Body:      body,
 		RespModel: &role,
 	})
@@ -177,10 +191,72 @@ func (d *oneloginRoleResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	newState, diags := d.read(ctx, role.ID)
+	// Calculate the added and removed users
+	var state oneloginRole
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	addUsers, removeUsers, diags := calculateAddRemoveUsers(ctx, plan.Users, state.Users)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Add users
+	if len(addUsers) > 0 {
+		var addUserResp []struct {
+			ID int64 `json:"id"`
+		}
+		err = d.client.ExecRequest(&onelogin.Request{
+			Context:   ctx,
+			Method:    onelogin.MethodPost,
+			Path:      fmt.Sprintf("%s/%d/users", onelogin.PathRoles, plan.ID.ValueInt64()),
+			Body:      addUsers,
+			RespModel: &addUserResp,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error adding users to role",
+				"Could not add users to role: "+err.Error(),
+			)
+			return
+		}
+		if len(addUserResp) != len(addUsers) {
+			resp.Diagnostics.AddError(
+				"Error adding users to role",
+				fmt.Sprintf("Could not add all users to role\nadddUserResp: %v\naddUsers: %v", addUserResp, addUsers),
+			)
+			return
+		}
+	}
+
+	// Delete users
+	if len(removeUsers) > 0 {
+		err = d.client.ExecRequest(&onelogin.Request{
+			Context: ctx,
+			Method:  onelogin.MethodDelete,
+			Path:    fmt.Sprintf("%s/%d/users", onelogin.PathRoles, plan.ID.ValueInt64()),
+			Body:    removeUsers,
+		})
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error removing users from role",
+				"Could not remove users from role: "+err.Error(),
+			)
+			return
+		}
+	}
+
+	// I think that add and delete may return prior to the transaction being fully committed.
+	// In the case the transaction is not fully committed, the read will produce inconsistent results.
+	// We will assume that user updates are eventually consistent and update the state to their expected value.
+	newState, diags := d.read(ctx, role.ID, plan.Users)
 	if diags.HasError() {
 		return
 	}
+	newState.Users = plan.Users
 
 	newState.LastUpdated = types.StringValue(util.GetTimestampString())
 
@@ -221,7 +297,7 @@ func (d *oneloginRoleResource) ImportState(ctx context.Context, req resource.Imp
 		return
 	}
 
-	state, diags := d.read(ctx, int64(id))
+	state, diags := d.read(ctx, int64(id), types.ListNull(types.Int64Type))
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -234,11 +310,9 @@ func (d *oneloginRoleResource) ImportState(ctx context.Context, req resource.Imp
 	}
 }
 
-func (d *oneloginRoleResource) read(ctx context.Context, id int64) (*oneloginRole, diag.Diagnostics) {
+func (d *oneloginRoleResource) read(ctx context.Context, id int64, trackedUsers types.List) (*oneloginRole, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
-	// This function doesn't even make any sense.  Query params need to be included
-	// but it is impossible to use query params when getting role by ID.
 	var role onelogin.Role
 	err := d.client.ExecRequest(&onelogin.Request{
 		Context:   ctx,
@@ -251,24 +325,30 @@ func (d *oneloginRoleResource) read(ctx context.Context, id int64) (*oneloginRol
 		return nil, diags
 	}
 
-	return roleToState(ctx, &role)
+	return roleToState(ctx, &role, trackedUsers)
 }
 
-func (state *oneloginRole) toNative(ctx context.Context) *onelogin.Role {
+func (state *oneloginRole) toNative(ctx context.Context) (*onelogin.Role, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+	newDiags := diag.Diagnostics{}
+
 	admins := []int64{}
-	if !state.Admins.IsNull() {
-		state.Admins.ElementsAs(ctx, &admins, false)
+	if !state.Admins.IsNull() && !state.Admins.IsUnknown() {
+		newDiags = state.Admins.ElementsAs(ctx, &admins, false)
 	}
+	diags.Append(newDiags...)
 
 	apps := []int64{}
-	if !state.Apps.IsNull() {
-		state.Apps.ElementsAs(ctx, &apps, false)
+	if !state.Apps.IsNull() && !state.Apps.IsUnknown() {
+		newDiags = state.Apps.ElementsAs(ctx, &apps, false)
 	}
+	diags.Append(newDiags...)
 
 	users := []int64{}
-	if !state.Users.IsNull() {
-		state.Users.ElementsAs(ctx, &users, false)
+	if !state.Users.IsNull() && !state.Users.IsUnknown() {
+		newDiags = state.Users.ElementsAs(ctx, &users, false)
 	}
+	diags.Append(newDiags...)
 
 	return &onelogin.Role{
 		ID:     state.ID.ValueInt64(),
@@ -276,10 +356,10 @@ func (state *oneloginRole) toNative(ctx context.Context) *onelogin.Role {
 		Admins: admins,
 		Apps:   apps,
 		Users:  users,
-	}
+	}, diags
 }
 
-func roleToState(ctx context.Context, role *onelogin.Role) (*oneloginRole, diag.Diagnostics) {
+func roleToState(ctx context.Context, role *onelogin.Role, trackedUsers types.List) (*oneloginRole, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 
 	state := &oneloginRole{
@@ -302,11 +382,72 @@ func roleToState(ctx context.Context, role *onelogin.Role) (*oneloginRole, diag.
 		state.Apps = apps
 	}
 
-	users, newDiags := types.ListValueFrom(ctx, types.Int64Type, role.Users)
-	diags.Append(newDiags...)
-	if len(users.Elements()) > 0 {
-		state.Users = users
+	if !trackedUsers.IsNull() && !trackedUsers.IsUnknown() {
+		trackedUsersIDs := []int64{}
+		newDiags = trackedUsers.ElementsAs(ctx, &trackedUsersIDs, false)
+		diags.Append(newDiags...)
+		if diags.HasError() {
+			return state, diags
+		}
+		trackedUsersIDsMap := map[int64]bool{}
+		for _, id := range trackedUsersIDs {
+			trackedUsersIDsMap[id] = true
+		}
+		roleUsersTracked := []int64{}
+		for _, id := range role.Users {
+			if _, ok := trackedUsersIDsMap[id]; ok {
+				roleUsersTracked = append(roleUsersTracked, id)
+			}
+		}
+		users, newDiags := types.ListValueFrom(ctx, types.Int64Type, roleUsersTracked)
+		diags.Append(newDiags...)
+		if len(users.Elements()) > 0 {
+			state.Users = users
+		}
 	}
 
 	return state, diags
+}
+
+// state = old state
+// plan = future state
+func calculateAddRemoveUsers(ctx context.Context, plan, state types.List) ([]int64, []int64, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	planUsers := []int64{}
+	newDiags := plan.ElementsAs(ctx, &planUsers, false)
+	diags.Append(newDiags...)
+
+	stateUsers := []int64{}
+	newDiags = state.ElementsAs(ctx, &stateUsers, false)
+	diags.Append(newDiags...)
+
+	if diags.HasError() {
+		return nil, nil, diags
+	}
+
+	add := []int64{}
+	remove := []int64{}
+
+	planUsersMap := map[int64]bool{}
+	for _, planUser := range planUsers {
+		planUsersMap[planUser] = true
+	}
+
+	stateUsersMap := map[int64]bool{}
+	for _, stateUser := range stateUsers {
+		stateUsersMap[stateUser] = true
+
+		if _, inPlan := planUsersMap[stateUser]; !inPlan {
+			remove = append(remove, stateUser)
+		}
+	}
+
+	for _, planUser := range planUsers {
+		if _, inState := stateUsersMap[planUser]; !inState {
+			add = append(add, planUser)
+		}
+	}
+
+	return add, remove, diags
 }

--- a/internal/provider/onelogin_role_test.go
+++ b/internal/provider/onelogin_role_test.go
@@ -210,13 +210,6 @@ func (s *providerTestSuite) TestAccOneloginRoleIntegrated() {
 					resource.TestCheckResourceAttrWith("onelogin_role.test_role", "apps.0", compareID("onelogin_app.test_app_2")),
 				),
 			},
-
-			{
-				ResourceName:            "onelogin_role.test_role",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"last_updated"},
-			},
 		},
 	})
 }
@@ -275,14 +268,20 @@ func (s *providerTestSuite) TestAccOneloginRoleImported() {
 					resource "onelogin_role" "test_role" {
 						name = "%v"
 						apps = [%v]
+						users = [data.onelogin_user.test.id]
 					}
-				`, role.Id, roleName, apps[0].ID),
+
+					data "onelogin_user" "test" {
+						username = "%v"
+					}
+				`, role.Id, roleName, apps[0].ID, users[1].Username),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_role.test_role", "name", roleName),
-					resource.TestCheckResourceAttr("onelogin_role.test_role", "users.#", "1"),
-					resource.TestCheckResourceAttr("onelogin_role.test_role", "users.0", fmt.Sprintf("%v", users[0].ID)),
 					resource.TestCheckResourceAttr("onelogin_role.test_role", "apps.#", "1"),
 					resource.TestCheckResourceAttr("onelogin_role.test_role", "apps.0", fmt.Sprintf("%v", apps[0].ID)),
+					resource.TestCheckResourceAttr("onelogin_role.test_role", "users.#", "1"),
+					resource.TestCheckResourceAttr("onelogin_role.test_role", "users.0", fmt.Sprintf("%v", users[1].ID)),
+					resource.TestCheckResourceAttrSet("data.onelogin_user.test", "id"),
 				),
 			},
 		},


### PR DESCRIPTION
Computed role users pose a problem when mappings set many users for many roles.  The number of nodes considered in the graph walk balloons and `terraform plan` crashes due to massive resource consumption.

This PR removes computed users from the state and allows the user to specify only certain users that are manually added and removed from the roles.