### PR TITLE
add logging to onelogin client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ website/vendor
 
 .vscode/
 tmp/
+run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ website/vendor
 .vscode/
 tmp/
 run.sh
+.envrc

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,12 @@
 default: testacc
 
 # Run acceptance tests
-.PHONY: testacc
-testacc:
+.PHONY: testacc lint
+testacc: lint
+	@[ -n "$(CLIENT_ID)" ] || (echo "CLIENT_ID must be set to run acceptance tests" && exit 1)
+	@[ -n "$(CLIENT_SECRET)" ] || (echo "CLIENT_SECRET must be set to run acceptance tests" && exit 1)
+	@[ -n "$(SUBDOMAIN)" ] || (echo "SUBDOMAIN must be set to run acceptance tests" && exit 1)
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+lint:
+	golangci-lint run

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/ghaggin/terraform-provider-onelogin/internal/util"
 	"github.com/ghaggin/terraform-provider-onelogin/onelogin"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -101,6 +102,9 @@ func (p *oneloginProvider) Configure(ctx context.Context, req provider.Configure
 		// but still complete after context cancellation, which leaves
 		// the state inconsistent.
 		Timeout: 60 * time.Second,
+
+		// Pass the terraform logger to the onelogin client
+		Logger: &util.TFLogger{},
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Unable to create client", err.Error())

--- a/internal/util/tflogger.go
+++ b/internal/util/tflogger.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// TFLogger is a wrapper around the terraform logger
+// to implement the onelogin.Logger interface
+type TFLogger struct {
+}
+
+func (*TFLogger) Trace(ctx context.Context, msg string, fields ...map[string]interface{}) {
+	tflog.Trace(ctx, msg, fields...)
+
+}
+func (*TFLogger) Debug(ctx context.Context, msg string, fields ...map[string]interface{}) {
+	tflog.Debug(ctx, msg, fields...)
+}
+
+func (*TFLogger) Info(ctx context.Context, msg string, fields ...map[string]interface{}) {
+	tflog.Info(ctx, msg, fields...)
+}
+
+func (*TFLogger) Warn(ctx context.Context, msg string, fields ...map[string]interface{}) {
+	tflog.Warn(ctx, msg, fields...)
+}
+
+func (*TFLogger) Error(ctx context.Context, msg string, fields ...map[string]interface{}) {
+	tflog.Error(ctx, msg, fields...)
+}

--- a/onelogin/logging.go
+++ b/onelogin/logging.go
@@ -120,7 +120,10 @@ func (d *devLogger) log(level LogLevel, msg string, fields ...map[string]interfa
 	}
 	buf.WriteString("\n")
 
-	d.fout.Write(buf.Bytes())
+	_, err := d.fout.Write(buf.Bytes())
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("error writing log: %v\n", err))
+	}
 }
 
 func logLevelToString(level LogLevel) string {

--- a/onelogin/logging.go
+++ b/onelogin/logging.go
@@ -1,0 +1,153 @@
+package onelogin
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+type LogLevel int
+
+const (
+	Trace LogLevel = iota
+	Debug
+	Info
+	Warn
+	Error
+)
+
+func StringToLogLevel(level string) (LogLevel, error) {
+	switch level {
+	case "trace":
+		return Trace, nil
+	case "debug":
+		return Debug, nil
+	case "info":
+		return Info, nil
+	case "warn":
+		return Warn, nil
+	case "error":
+		return Error, nil
+	default:
+		return 0, fmt.Errorf("invalid log level: %v", level)
+	}
+}
+
+type Logger interface {
+	Trace(ctx context.Context, msg string, fields ...map[string]interface{})
+	Debug(ctx context.Context, msg string, fields ...map[string]interface{})
+	Info(ctx context.Context, msg string, fields ...map[string]interface{})
+	Warn(ctx context.Context, msg string, fields ...map[string]interface{})
+	Error(ctx context.Context, msg string, fields ...map[string]interface{})
+}
+
+type noopLogger struct{}
+
+func NewNoopLogger() Logger {
+	return &noopLogger{}
+}
+
+func (n *noopLogger) Trace(_ context.Context, msg string, fields ...map[string]interface{}) {}
+func (n *noopLogger) Debug(_ context.Context, msg string, fields ...map[string]interface{}) {}
+func (n *noopLogger) Info(_ context.Context, msg string, fields ...map[string]interface{})  {}
+func (n *noopLogger) Warn(_ context.Context, msg string, fields ...map[string]interface{})  {}
+func (n *noopLogger) Error(_ context.Context, msg string, fields ...map[string]interface{}) {}
+
+type devLogger struct {
+	level LogLevel
+	fout  *os.File
+	mu    sync.Mutex
+}
+
+func NewDevLogger(level LogLevel, fout *os.File) Logger {
+	return &devLogger{
+		level: level,
+		fout:  fout,
+		mu:    sync.Mutex{},
+	}
+}
+
+func (d *devLogger) Trace(_ context.Context, msg string, fields ...map[string]interface{}) {
+	if d.level <= Trace {
+		d.log(Trace, msg, fields...)
+		return
+	}
+}
+
+func (d *devLogger) Debug(_ context.Context, msg string, fields ...map[string]interface{}) {
+	if d.level <= Debug {
+		d.log(Debug, msg, fields...)
+		return
+	}
+}
+func (d *devLogger) Info(_ context.Context, msg string, fields ...map[string]interface{}) {
+	if d.level <= Info {
+		d.log(Info, msg, fields...)
+		return
+	}
+}
+func (d *devLogger) Warn(_ context.Context, msg string, fields ...map[string]interface{}) {
+	if d.level <= Warn {
+		d.log(Warn, msg, fields...)
+		return
+	}
+}
+func (d *devLogger) Error(_ context.Context, msg string, fields ...map[string]interface{}) {
+	// errors are always printed
+	d.log(Error, msg, fields...)
+}
+
+func (d *devLogger) log(level LogLevel, msg string, fields ...map[string]interface{}) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	levelStr := logLevelToString(level)
+	fieldsMerged := mergFields(fields...)
+	fieldKeys := []string{}
+	for k := range fieldsMerged {
+		fieldKeys = append(fieldKeys, k)
+	}
+	sort.StringSlice(fieldKeys).Sort()
+
+	buf := bytes.Buffer{}
+	buf.WriteString(fmt.Sprintf("%v   %v   %v", time.Now().UTC().Format(time.RFC3339), levelStr, msg))
+	for _, k := range fieldKeys {
+		buf.WriteString(fmt.Sprintf("   %v: %v", k, fieldsMerged[k]))
+	}
+	buf.WriteString("\n")
+
+	d.fout.Write(buf.Bytes())
+}
+
+func logLevelToString(level LogLevel) string {
+	switch level {
+	case Trace:
+		return "TRACE"
+	case Debug:
+		return "DEBUG"
+	case Info:
+		return "INFO"
+	case Warn:
+		return "WARN"
+	case Error:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func mergFields(fields ...map[string]interface{}) map[string]interface{} {
+	merged := map[string]interface{}{}
+
+	for _, f := range fields {
+		for k, v := range f {
+			merged[k] = v
+		}
+	}
+
+	return merged
+}


### PR DESCRIPTION
Add a logging interface to the OneLogin client.  Pass a tflog wrapper to the OneLogin client in the provider.