### PR TITLE
Fix mapping delete issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.8.0
+	github.com/jarcoal/httpmock v1.3.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
@@ -144,6 +146,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=

--- a/internal/provider/onelogin_app.go
+++ b/internal/provider/onelogin_app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -471,6 +472,16 @@ func (d *oneloginAppResource) Delete(ctx context.Context, req resource.DeleteReq
 		Method:  onelogin.MethodDelete,
 		Path:    fmt.Sprintf("%s/%v", onelogin.PathApps, state.ID.ValueInt64()),
 	})
+
+	// consider NotFound a success
+	if err == onelogin.ErrNotFound {
+		tflog.Warn(ctx, "app to delete not found", map[string]interface{}{
+			"name": state.Name.ValueString(),
+			"id":   state.ID.ValueInt64(),
+		})
+		return
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting app",

--- a/internal/provider/onelogin_mapping.go
+++ b/internal/provider/onelogin_mapping.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -249,6 +250,16 @@ func (d *oneloginMappingResource) Delete(ctx context.Context, req resource.Delet
 		Method:  onelogin.MethodDelete,
 		Path:    fmt.Sprintf("%s/%v", onelogin.PathMappings, id),
 	})
+
+	// consider NotFound a success
+	if err == onelogin.ErrNotFound {
+		tflog.Warn(ctx, "mapping to delete not found", map[string]interface{}{
+			"name": state.Name.ValueString(),
+			"id":   state.ID.ValueInt64(),
+		})
+		return
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting mapping",

--- a/internal/provider/onelogin_mapping_order_test.go
+++ b/internal/provider/onelogin_mapping_order_test.go
@@ -105,11 +105,18 @@ func (s *providerTestSuite) TestAccResourceMappingOrderIntegrated() {
 		disabledIDs[i] = strconv.Itoa(int(m.ID))
 	}
 
+	maybeComma := func(s []string) string {
+		if len(s) > 0 {
+			return ","
+		}
+		return ""
+	}
+
 	enabledStr := "[" + strings.Join(enabledIDs, ",") + "]"
-	enabledStrWithNewResource1 := "[" + strings.Join(enabledIDs, ",") + ",onelogin_mapping.test.id]"
-	enabledStrWithNewResource2 := "[onelogin_mapping.test.id," + strings.Join(enabledIDs, ",") + "]"
+	enabledStrWithNewResource1 := "[" + strings.Join(enabledIDs, ",") + maybeComma(enabledIDs) + "onelogin_mapping.test.id]"
+	enabledStrWithNewResource2 := "[onelogin_mapping.test.id" + maybeComma(enabledIDs) + strings.Join(enabledIDs, ",") + "]"
 	disabledStr := "[" + strings.Join(disabledIDs, ",") + "]"
-	disabledStrWithNewResource := "[" + strings.Join(disabledIDs, ",") + ",onelogin_mapping.test.id]"
+	disabledStrWithNewResource := "[" + strings.Join(disabledIDs, ",") + maybeComma(disabledIDs) + "onelogin_mapping.test.id]"
 
 	resource.Test(s.T(), resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -246,9 +253,16 @@ func (s *providerTestSuite) TestAccResourceMappingOrderIntegratedDisabledOrderin
 		disabledIDs[i] = strconv.Itoa(int(m.ID))
 	}
 
+	maybeComma := func(s []string) string {
+		if len(s) > 0 {
+			return ","
+		}
+		return ""
+	}
+
 	enabledStr := "[" + strings.Join(enabledIDs, ",") + "]"
-	disabledStrWithNewResource1 := "[onelogin_mapping.test2.id," + strings.Join(disabledIDs, ",") + ",onelogin_mapping.test1.id]"
-	disabledStrWithNewResource2 := "[" + strings.Join(disabledIDs, ",") + ",onelogin_mapping.test1.id,onelogin_mapping.test2.id]"
+	disabledStrWithNewResource1 := "[onelogin_mapping.test2.id" + maybeComma(disabledIDs) + strings.Join(disabledIDs, ",") + ",onelogin_mapping.test1.id]"
+	disabledStrWithNewResource2 := "[" + strings.Join(disabledIDs, ",") + maybeComma(disabledIDs) + "onelogin_mapping.test1.id,onelogin_mapping.test2.id]"
 
 	resource.Test(s.T(), resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,

--- a/internal/provider/onelogin_mapping_test.go
+++ b/internal/provider/onelogin_mapping_test.go
@@ -146,24 +146,6 @@ func (s *providerTestSuite) Test_CreateAndDeleteLotsOfMappings() {
 	s.Equal(0, len(enabled))
 }
 
-func (s *providerTestSuite) Test_DeleteOneMapping() {
-	err := s.client.ExecRequest(&onelogin.Request{
-		Method: onelogin.MethodDelete,
-		Path:   fmt.Sprintf("%s/%d", onelogin.PathMappings, 608139),
-
-		Retry:     3,
-		RetryWait: time.Second,
-	})
-	s.Require().NoError(err)
-
-	mo := oneloginMappingOrderResource{s.client}
-	_, diags := mo.getEnabled(context.Background())
-	if diags.HasError() {
-		s.False(diags.HasError())
-		s.T().Log(diags.Errors())
-	}
-}
-
 func (s *providerTestSuite) Test_mappingToState() {
 	id := int64(1234)
 	name := "test_name"

--- a/internal/provider/onelogin_mapping_test.go
+++ b/internal/provider/onelogin_mapping_test.go
@@ -3,12 +3,166 @@ package provider
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/ghaggin/terraform-provider-onelogin/onelogin"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+// DELETE TEST MAPPINGS
+// This is useful for cleaning up tests that leave the instance in a
+// corrupted state.
+//
+// Only run ad hoc when other load tests require cleanup.
+func (s *providerTestSuite) Test_DeleteMappings() {
+	if os.Getenv("LOAD_TEST") != "1" {
+		return
+	}
+
+	mo := oneloginMappingOrderResource{s.client}
+	_, diags := mo.getEnabled(context.Background())
+	s.False(diags.HasError())
+
+	var enabled []onelogin.Mapping
+	err := s.client.ExecRequest(&onelogin.Request{
+		Method:    onelogin.MethodGet,
+		Path:      onelogin.PathMappings,
+		RespModel: &enabled,
+	})
+	s.Require().NoError(err)
+
+	sort.Slice(enabled, func(i, j int) bool {
+		return *enabled[i].Position > *enabled[j].Position
+	})
+
+	for _, m := range enabled {
+		if strings.Contains(m.Name, "terraform_test_") {
+			fmt.Printf("Deleting mapping %s [%d]\n", m.Name, m.ID)
+			err = s.client.ExecRequest(&onelogin.Request{
+				Method: onelogin.MethodDelete,
+				Path:   fmt.Sprintf("%s/%d", onelogin.PathMappings, m.ID),
+			})
+
+			if err != nil {
+				fmt.Printf("Error deleting mapping %s [%d]: %v\n", m.Name, m.ID, err)
+			}
+		}
+	}
+}
+
+// This test demonstrates how to delete a large number of mappings in
+// multiple threads.
+//
+// Only run when LOAD_TEST is 1.  This test runs for >10 min.
+func (s *providerTestSuite) Test_CreateAndDeleteLotsOfMappings() {
+	if os.Getenv("LOAD_TEST") != "1" {
+		return
+	}
+
+	ctx := context.Background()
+
+	numMappings := 1000
+	for i := 0; i < numMappings; i++ {
+		mapping := onelogin.Mapping{
+			Name:  fmt.Sprintf("terraform_test_%d", i),
+			Match: "all",
+			Conditions: []onelogin.MappingCondition{
+				{
+					Source:   "last_login",
+					Operator: ">",
+					Value:    "90",
+				},
+			},
+			Actions: []onelogin.MappingAction{
+				{
+					Action: "set_status",
+					Value:  []string{"2"},
+				},
+			},
+			Enabled:  true,
+			Position: nil,
+		}
+
+		fmt.Printf("creating mapping %d\n", i)
+		err := s.client.ExecRequest(&onelogin.Request{
+			Method: onelogin.MethodPost,
+			Path:   onelogin.PathMappings,
+			Body:   &mapping,
+		})
+		s.Require().NoError(err)
+	}
+
+	mo := oneloginMappingOrderResource{s.client}
+	enabled, diags := mo.getEnabled(context.Background())
+	if diags.HasError() {
+		s.False(diags.HasError())
+		s.T().Log(diags.Errors())
+	}
+
+	numWorkers := 10
+	wg := &sync.WaitGroup{}
+	wg.Add(10)
+	type deleteRequest struct {
+		ID  int64
+		Num int
+	}
+	queue := make(chan deleteRequest, numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			for r := range queue {
+				fmt.Printf("deleting mapping %d\n", r.Num)
+				err := s.client.ExecRequest(&onelogin.Request{
+					Method: onelogin.MethodDelete,
+					Path:   fmt.Sprintf("%s/%v", onelogin.PathMappings, r.ID),
+
+					Retry:                10,
+					RetryWait:            time.Second,
+					RetryBackoffFactor:   1,
+					RetriableStatusCodes: []int{404, 429, 500, 502, 504},
+				})
+				s.NoError(err)
+			}
+		}()
+	}
+
+	for i, mapping := range enabled {
+		queue <- deleteRequest{
+			Num: i,
+			ID:  mapping.ID,
+		}
+	}
+	close(queue)
+	wg.Wait()
+
+	enabled, diags = mo.getEnabled(ctx)
+	s.Require().False(diags.HasError())
+	s.Equal(0, len(enabled))
+}
+
+func (s *providerTestSuite) Test_DeleteOneMapping() {
+	err := s.client.ExecRequest(&onelogin.Request{
+		Method: onelogin.MethodDelete,
+		Path:   fmt.Sprintf("%s/%d", onelogin.PathMappings, 608139),
+
+		Retry:     3,
+		RetryWait: time.Second,
+	})
+	s.Require().NoError(err)
+
+	mo := oneloginMappingOrderResource{s.client}
+	_, diags := mo.getEnabled(context.Background())
+	if diags.HasError() {
+		s.False(diags.HasError())
+		s.T().Log(diags.Errors())
+	}
+}
 
 func (s *providerTestSuite) Test_mappingToState() {
 	id := int64(1234)
@@ -180,14 +334,21 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 		disabledIDs[i] = strconv.Itoa(int(m.ID))
 	}
 
+	maybeComma := func(s []string) string {
+		if len(s) > 0 {
+			return ","
+		}
+		return ""
+	}
+
 	resource.Test(s.T(), resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: s.providerConfig + fmt.Sprintf(`
 					resource "onelogin_mapping_order" "test" {
-						enabled = %v
-						disabled = %v
+						enabled = [%v]
+						disabled = [%v]
 					}
 
 					resource "onelogin_mapping" "test" {
@@ -207,7 +368,7 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 							}
 						]
 					}
-				`, "["+strings.Join(enabledIDs, ",")+"]", "["+strings.Join(disabledIDs, ",")+",onelogin_mapping.test.id]"),
+				`, strings.Join(enabledIDs, ","), strings.Join(disabledIDs, ",")+maybeComma(disabledIDs)+"onelogin_mapping.test.id"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled))),
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled)+1)),
@@ -224,8 +385,8 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 			{
 				Config: s.providerConfig + fmt.Sprintf(`
 					resource "onelogin_mapping_order" "test" {
-						enabled = %v
-						disabled = %v
+						enabled = [%v]
+						disabled = [%v]
 					}
 
 					resource "onelogin_mapping" "test" {
@@ -245,7 +406,7 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 							}
 						]
 					}
-				`, "[onelogin_mapping.test.id,"+strings.Join(enabledIDs, ",")+"]", "["+strings.Join(disabledIDs, ",")+"]"),
+				`, "onelogin_mapping.test.id"+maybeComma(enabledIDs)+strings.Join(enabledIDs, ","), strings.Join(disabledIDs, ",")),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled)+1)),
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled))),
@@ -262,8 +423,8 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 			{
 				Config: s.providerConfig + fmt.Sprintf(`
 					resource "onelogin_mapping_order" "test" {
-						enabled = %v
-						disabled = %v
+						enabled = [%v]
+						disabled = [%v]
 					}
 
 					resource "onelogin_mapping" "test" {
@@ -288,7 +449,7 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 							}
 						]
 					}
-				`, "[onelogin_mapping.test.id,"+strings.Join(enabledIDs, ",")+"]", "["+strings.Join(disabledIDs, ",")+"]"),
+				`, "onelogin_mapping.test.id"+maybeComma(enabledIDs)+strings.Join(enabledIDs, ","), strings.Join(disabledIDs, ",")),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled)+1)),
 					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled))),
@@ -301,6 +462,157 @@ func (s *providerTestSuite) TestAccResourceMappingEnabled() {
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "actions.0.action", "set_status"),
 					resource.TestCheckResourceAttr("onelogin_mapping.test", "actions.0.value.0", "2"),
 				),
+			},
+			{
+				// delete all resources
+				Config: s.providerConfig,
+			},
+			{
+				Config: s.providerConfig + fmt.Sprintf(`
+					resource "onelogin_mapping_order" "test" {
+						enabled = [%v]
+						disabled = [%v]
+					}
+
+					resource "onelogin_mapping" "test_2" {
+						name = "test_mapping_enabled"
+						match = "all"
+						conditions = [
+							{
+								source = "last_login"
+								operator = ">"
+								value = "90"
+							},
+							{
+								operator = "!~"
+								source   = "member_of"
+								value    = "cn=test_group,"
+							}
+						]
+						actions = [
+							{
+								action = "set_status"
+								value = ["2"]
+							}
+						]
+					}
+				`, "onelogin_mapping.test_2.id"+maybeComma(enabledIDs)+strings.Join(enabledIDs, ","), strings.Join(disabledIDs, ",")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "enabled.#", fmt.Sprintf("%v", len(enabled)+1)),
+					resource.TestCheckResourceAttr("onelogin_mapping_order.test", "disabled.#", fmt.Sprintf("%v", len(disabled))),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "name", "test_mapping_enabled"),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "match", "all"),
+					resource.TestCheckResourceAttrSet("onelogin_mapping.test_2", "id"),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "conditions.0.source", "last_login"),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "conditions.0.operator", ">"),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "conditions.0.value", "90"),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "actions.0.action", "set_status"),
+					resource.TestCheckResourceAttr("onelogin_mapping.test_2", "actions.0.value.0", "2"),
+				),
+			},
+		},
+	})
+}
+
+// Only run the mapping load test if the environment variable
+// LOAD_TEST is set to 1.  This test takes >10 min to run
+// so should only be explicitly tested as needed.
+func (s *providerTestSuite) TestAccResourceMappingLoad() {
+	if os.Getenv("LOAD_TEST") != "1" {
+		return
+	}
+
+	// get all the enabled and disabled mappings
+	ctx := context.Background()
+
+	mappingOrderResource := oneloginMappingOrderResource{
+		client: s.client,
+	}
+
+	enabled, diags := mappingOrderResource.getEnabled(ctx)
+	s.Require().Nil(diags, diags.Errors())
+
+	disabled, diags := mappingOrderResource.getDisabled(ctx)
+	s.Require().Nil(diags, diags.Errors())
+
+	enabledIDs := make([]string, len(enabled))
+	for i, m := range enabled {
+		enabledIDs[i] = strconv.Itoa(int(m.ID))
+	}
+
+	disabledIDs := make([]string, len(disabled))
+	for i, m := range disabled {
+		disabledIDs[i] = strconv.Itoa(int(m.ID))
+	}
+
+	mapping := func(i int) string {
+		return fmt.Sprintf(`
+			resource "onelogin_mapping" "terraform_test_%d" {
+				name = "terraform_test_%d"
+				match = "all"
+				conditions = [
+					{
+						source = "last_login"
+						operator = ">"
+						value = "90"
+					}
+				]
+				actions = [
+					{
+						action = "set_status"
+						value = ["2"]
+					}
+				]
+			}
+		`, i, i)
+	}
+
+	totalMappings := 1000
+
+	enabledStart := enabledIDs
+	configStart := &strings.Builder{}
+	configStart.WriteString(s.providerConfig)
+	for i := 0; i < totalMappings; i++ {
+		configStart.WriteString(mapping(i))
+		enabledStart = append(enabledStart, fmt.Sprintf("onelogin_mapping.terraform_test_%d.id", i))
+	}
+	configStart.WriteString(fmt.Sprintf(`
+		resource "onelogin_mapping_order" "test" {
+			enabled = [%s]
+			disabled = [%s]
+		}
+	`, strings.Join(enabledStart, ","), strings.Join(disabledIDs, ",")))
+
+	enabledUpdated := enabledIDs
+	configUpdated := &strings.Builder{}
+	configUpdated.WriteString(s.providerConfig)
+	for i := 0; i < totalMappings; i++ {
+		// delete every fifth mapping
+		if i%5 == 0 {
+			continue
+		}
+		configUpdated.WriteString(mapping(i))
+		enabledUpdated = append(enabledUpdated, fmt.Sprintf("onelogin_mapping.terraform_test_%d.id", i))
+	}
+	rand.Shuffle(len(enabledUpdated), func(i, j int) { enabledUpdated[i], enabledUpdated[j] = enabledUpdated[j], enabledUpdated[i] })
+	configUpdated.WriteString(fmt.Sprintf(`
+		resource "onelogin_mapping_order" "test" {
+			enabled = [%s]
+			disabled = [%s]
+		}
+	`, strings.Join(enabledUpdated, ","), strings.Join(disabledIDs, ",")))
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configStart.String(),
+			},
+			{
+				Config: configUpdated.String(),
+			},
+			{
+				Config: s.providerConfig,
 			},
 		},
 	})

--- a/internal/provider/onelogin_role.go
+++ b/internal/provider/onelogin_role.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -281,6 +282,16 @@ func (d *oneloginRoleResource) Delete(ctx context.Context, req resource.DeleteRe
 		Method:  onelogin.MethodDelete,
 		Path:    fmt.Sprintf("%s/%v", onelogin.PathRoles, state.ID.ValueInt64()),
 	})
+
+	// consider NotFound a success
+	if err == onelogin.ErrNotFound {
+		tflog.Warn(ctx, "role to delete not found", map[string]interface{}{
+			"name": state.Name.ValueString(),
+			"id":   state.ID.ValueInt64(),
+		})
+		return
+	}
+
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting role",

--- a/onelogin/client.go
+++ b/onelogin/client.go
@@ -90,10 +90,10 @@ type Request struct {
 	RetriableStatusCodes []int
 
 	// RetryWait is the time that will be waited for between retry attempts.
-	// This will be multipled by the RetryBackoffFactor for subsequent retries
+	// This will be multiplied by the RetryBackoffFactor for subsequent retries
 	RetryWait time.Duration
 
-	// RetryBackoffFactor is the factor by which the RetryWait will be mutliplied
+	// RetryBackoffFactor is the factor by which the RetryWait will be multiplied
 	// for subsequent retries.
 	//
 	// E.g. if the RetryWait is 1 sec and the RetryBackoffFactor is 2, then the 1st

--- a/onelogin/client.go
+++ b/onelogin/client.go
@@ -17,6 +17,7 @@ const (
 )
 
 var (
+	ErrNotFound          = fmt.Errorf("not found")
 	ErrRateLimitExceeded = fmt.Errorf("rate limit exceeded")
 	ErrBadGateway        = fmt.Errorf("bad gateway")
 	ErrNoMorePages       = fmt.Errorf("no more pages")
@@ -230,6 +231,8 @@ func (c *Client) ExecRequest(req *Request) (err error) {
 	} else if resp.StatusCode/100 != 2 {
 		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("request failed with status code %d\n%s", resp.StatusCode, string(bodyBytes))
+	} else if resp.StatusCode == 404 {
+		return ErrNotFound
 	}
 
 	if req.RespModel != nil {

--- a/onelogin/client_integration_test.go
+++ b/onelogin/client_integration_test.go
@@ -1,0 +1,115 @@
+package onelogin
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type clientIntegrationTestSuite struct {
+	suite.Suite
+
+	clientID     string
+	clientSecret string
+	subdomain    string
+
+	client *Client
+
+	ctx context.Context
+}
+
+func (s *clientIntegrationTestSuite) SetupTest() {
+	c, err := NewClient(&ClientConfig{
+		ClientID:     s.clientID,
+		ClientSecret: s.clientSecret,
+		Subdomain:    s.subdomain,
+	})
+	s.Require().NoError(err)
+	s.client = c
+}
+
+func TestClientIntegration(t *testing.T) {
+	clientTestSuite := &clientIntegrationTestSuite{
+		clientID:     os.Getenv("CLIENT_ID"),
+		clientSecret: os.Getenv("CLIENT_SECRET"),
+		subdomain:    os.Getenv("SUBDOMAIN"),
+
+		ctx: context.Background(),
+	}
+
+	suite.Run(t, clientTestSuite)
+}
+
+func (s *clientIntegrationTestSuite) Test_getToken() {
+	testToken := "test_token"
+	testExpiration := time.Now().Add(time.Hour)
+
+	c := &Client{
+		config: &ClientConfig{
+			ClientID:     "",
+			ClientSecret: "",
+			Subdomain:    "",
+		},
+		authToken:      testToken,
+		authExpiration: testExpiration,
+		httpClient:     &http.Client{},
+	}
+	token, err := c.getToken(s.ctx)
+	s.Require().NoError(err)
+	s.Equal(testToken, token)
+	s.Equal(token, c.authToken)
+	s.Equal(testExpiration, c.authExpiration)
+
+	c.authExpiration = time.Time{}
+	token, err = c.getToken(s.ctx)
+	s.Error(err)
+	s.Equal("", token)
+	s.Equal(token, c.authToken)
+	s.Equal(time.Time{}, c.authExpiration)
+
+	c.config.ClientID = s.clientID
+	c.config.ClientSecret = s.clientSecret
+	c.config.Subdomain = s.subdomain
+
+	token, err = c.getToken(s.ctx)
+	s.Require().NoError(err)
+	s.NotEqual("", token)
+	s.NotEqual(testToken, c.authToken)
+	s.Equal(token, c.authToken)
+	s.NotEqual(testExpiration, c.authExpiration)
+	s.NotEqual(time.Time{}, c.authExpiration)
+	s.True(time.Now().Before(c.authExpiration))
+}
+
+func (s *clientIntegrationTestSuite) Test_ExecRequestPaged() {
+	var resp1 []Role
+	err := s.client.ExecRequestPaged(&Request{
+		Method:    MethodGet,
+		Path:      PathRoles,
+		RespModel: &resp1,
+	}, &Page{
+		Limit: 2,
+		Page:  1,
+	})
+	s.Require().NoError(err)
+
+	var resp2 []Role
+	err = s.client.ExecRequestPaged(&Request{
+		Method:    MethodGet,
+		Path:      PathRoles,
+		RespModel: &resp2,
+	}, &Page{
+		Limit: 1,
+		Page:  2,
+	})
+	s.Require().NoError(err)
+
+	s.Require().Equal(2, len(resp1))
+	s.Require().Equal(1, len(resp2))
+
+	s.Equal(resp1[1].ID, resp2[0].ID)
+}

--- a/onelogin/client_test.go
+++ b/onelogin/client_test.go
@@ -1,12 +1,19 @@
 package onelogin
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
-	"os"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,7 +29,29 @@ type clientTestSuite struct {
 	ctx context.Context
 }
 
+func TestRunClientTestSuite(t *testing.T) {
+	s := &clientTestSuite{
+		clientID:     "test_client_id",
+		clientSecret: "test_client_secret",
+		subdomain:    "test_subdomain",
+	}
+	suite.Run(t, s)
+}
+
 func (s *clientTestSuite) SetupTest() {
+	authResponder, err := httpmock.NewJsonResponder(200, &authResponse{
+		AccessToken:  "test_access_token",
+		CreatedAt:    time.Now().UTC(),
+		ExpiresIn:    int((time.Hour * 10).Seconds()),
+		RefreshToken: "test_refresh_token",
+		TokenType:    "bearer",
+		AccountID:    0,
+	})
+	s.Require().NoError(err)
+
+	httpmock.Activate()
+	httpmock.RegisterResponder(http.MethodPost, "https://test_subdomain.onelogin.com/auth/oauth2/v2/token", authResponder)
+
 	c, err := NewClient(&ClientConfig{
 		ClientID:     s.clientID,
 		ClientSecret: s.clientSecret,
@@ -30,86 +59,191 @@ func (s *clientTestSuite) SetupTest() {
 	})
 	s.Require().NoError(err)
 	s.client = c
+
 }
 
-func TestClient(t *testing.T) {
-	clientTestSuite := &clientTestSuite{
-		clientID:     os.Getenv("CLIENT_ID"),
-		clientSecret: os.Getenv("CLIENT_SECRET"),
-		subdomain:    os.Getenv("SUBDOMAIN"),
+func (s *clientTestSuite) TearDownTest() {
+	httpmock.Deactivate()
+}
 
-		ctx: context.Background(),
+func (s *clientTestSuite) Test_IsRetriable() {
+	s.True(s.client.isRetriable(500, []int{504, 503, 500, 501}))
+	s.False(s.client.isRetriable(401, []int{504, 503, 500, 501}))
+}
+
+func (s *clientTestSuite) Test_Retries() {
+	request := &Request{
+		Method: MethodGet,
+		Path:   "/test",
+
+		Retry:                3,
+		RetriableStatusCodes: []int{500},
+		RetryBackoffFactor:   1,
+		RetryWait:            time.Second * 0,
 	}
 
-	suite.Run(t, clientTestSuite)
+	// Test that all retries are exhausted and the last failure causes an error to be returned
+	timesCalled := 0
+	httpmock.RegisterResponder(string(MethodGet), "https://test_subdomain.onelogin.com/test", func(req *http.Request) (*http.Response, error) {
+		timesCalled++
+		return &http.Response{
+			StatusCode: 500,
+		}, nil
+	})
+	err := s.client.ExecRequest(request)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "request failed with status code 500")
+	s.Equal(4, timesCalled)
+
+	// Test that it retries after one failure and then returns successfully after success.
+	// Create a test response struct that will be returns as a json and processed.
+	timesCalled = 0
+	type testRespModel struct {
+		Test string `json:"test"`
+	}
+	var resp testRespModel
+	request.RespModel = &resp
+	testRespContent := "test_resp_content"
+	httpmock.RegisterResponder(string(MethodGet), "https://test_subdomain.onelogin.com/test", func(req *http.Request) (*http.Response, error) {
+		timesCalled++
+		if timesCalled == 2 {
+			b, err := json.Marshal(testRespModel{Test: testRespContent})
+			s.Require().NoError(err)
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader(b)),
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: 500,
+		}, nil
+	})
+	err = s.client.ExecRequest(request)
+	s.Require().NoError(err)
+	s.Equal(testRespContent, resp.Test)
+	s.Equal(2, timesCalled)
+
+	// Test context cancelation while waiting while waiting to retry
+	timesCalled = 0
+	called := make(chan bool, 1)
+	defer close(called)
+	httpmock.RegisterResponder(string(MethodGet), "https://test_subdomain.onelogin.com/test", func(req *http.Request) (*http.Response, error) {
+		timesCalled++
+		called <- true
+		return &http.Response{
+			StatusCode: 500,
+		}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	request.Context = ctx
+	request.RetryWait = time.Hour
+	go func() {
+		<-called
+		time.Sleep(time.Millisecond * 100)
+		cancel()
+	}()
+	err = s.client.ExecRequest(request)
+	s.Require().Error(err)
+	s.Equal("context canceled", err.Error())
+	s.Equal(1, timesCalled)
+
+	// Test retry backoff set to 0
+	// This means that there will be the same wait period for each retry
+	timesCalled = 0
+	timeCalled := make([]time.Time, 4)
+	httpmock.RegisterResponder(string(MethodGet), "https://test_subdomain.onelogin.com/test", func(req *http.Request) (*http.Response, error) {
+		timeCalled[timesCalled] = time.Now()
+		timesCalled++
+		return &http.Response{
+			StatusCode: 500,
+		}, nil
+	})
+	request.Context = context.Background()
+	request.RetryWait = time.Millisecond * 100
+	request.RetryBackoffFactor = 0
+	s.client.ExecRequest(request)
+	s.Require().Equal(4, timesCalled)
+	timeBetween := []time.Duration{
+		timeCalled[1].Sub(timeCalled[0]),
+		timeCalled[2].Sub(timeCalled[1]),
+		timeCalled[3].Sub(timeCalled[2]),
+	}
+	for _, d := range timeBetween {
+		s.Greater(d, request.RetryWait)
+		s.Greater(request.RetryWait*2, d)
+	}
+
+	// Test retry backoff set to 1
+	// This means that there will be an exponentially increasing backoff by powers of 2.
+	timesCalled = 0
+	timeCalled = make([]time.Time, 4)
+	httpmock.RegisterResponder(string(MethodGet), "https://test_subdomain.onelogin.com/test", func(req *http.Request) (*http.Response, error) {
+		timeCalled[timesCalled] = time.Now()
+		timesCalled++
+		return &http.Response{
+			StatusCode: 500,
+		}, nil
+	})
+	request.Context = context.Background()
+	request.RetryWait = time.Millisecond * 100
+	request.RetryBackoffFactor = 1
+	s.client.ExecRequest(request)
+	s.Require().Equal(4, timesCalled)
+	timeBetween = []time.Duration{
+		timeCalled[1].Sub(timeCalled[0]),
+		timeCalled[2].Sub(timeCalled[1]),
+		timeCalled[3].Sub(timeCalled[2]),
+	}
+	for i, d := range timeBetween {
+		s.Greater(d, request.RetryWait*time.Duration(pow(2, i)))
+		s.Greater((request.RetryWait*time.Duration(pow(2, i)))+request.RetryWait, d)
+	}
 }
 
-func (s *clientTestSuite) Test_getToken() {
-	testToken := "test_token"
-	testExpiration := time.Now().Add(time.Hour)
+func TestAuth(t *testing.T) {
+	ctx := context.Background()
 
 	c := &Client{
 		config: &ClientConfig{
-			ClientID:     "",
-			ClientSecret: "",
-			Subdomain:    "",
+			Subdomain:    "test_subdomain",
+			ClientID:     "test_client_id",
+			ClientSecret: "test_client_secret",
 		},
-		authToken:      testToken,
-		authExpiration: testExpiration,
-		httpClient:     &http.Client{},
+		log:        NewNoopLogger(),
+		httpClient: &http.Client{},
 	}
-	token, err := c.getToken(s.ctx)
-	s.Require().NoError(err)
-	s.Equal(testToken, token)
-	s.Equal(token, c.authToken)
-	s.Equal(testExpiration, c.authExpiration)
 
-	c.authExpiration = time.Time{}
-	token, err = c.getToken(s.ctx)
-	s.Error(err)
-	s.Equal("", token)
-	s.Equal(token, c.authToken)
-	s.Equal(time.Time{}, c.authExpiration)
+	authResponse := &authResponse{
+		AccessToken:  "test_access_token",
+		CreatedAt:    time.Now().UTC(),
+		ExpiresIn:    int((time.Hour * 10).Seconds()),
+		RefreshToken: "test_refresh_token",
+		TokenType:    "bearer",
+		AccountID:    0,
+	}
 
-	c.config.ClientID = s.clientID
-	c.config.ClientSecret = s.clientSecret
-	c.config.Subdomain = s.subdomain
+	authResponder, err := httpmock.NewJsonResponder(200, authResponse)
+	require.NoError(t, err)
+	httpmock.Activate()
+	defer httpmock.Deactivate()
+	httpmock.RegisterResponder(http.MethodPost, "https://test_subdomain.onelogin.com/auth/oauth2/v2/token", authResponder)
+	resp, err := c.authRequest(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, authResponse, resp)
 
-	token, err = c.getToken(s.ctx)
-	s.Require().NoError(err)
-	s.NotEqual("", token)
-	s.NotEqual(testToken, c.authToken)
-	s.Equal(token, c.authToken)
-	s.NotEqual(testExpiration, c.authExpiration)
-	s.NotEqual(time.Time{}, c.authExpiration)
-	s.True(time.Now().Before(c.authExpiration))
-}
+	testErr := errors.New("test_error")
+	httpmock.Deactivate()
+	httpmock.Activate()
+	httpmock.RegisterResponder(http.MethodPost, "https://test_subdomain.onelogin.com/auth/oauth2/v2/token", httpmock.NewErrorResponder(testErr))
+	_, err = c.authRequest(ctx)
+	assert.Equal(t, testErr, err.(*url.Error).Err)
 
-func (s *clientTestSuite) Test_ExecRequestPaged() {
-	var resp1 []Role
-	err := s.client.ExecRequestPaged(&Request{
-		Method:    MethodGet,
-		Path:      PathRoles,
-		RespModel: &resp1,
-	}, &Page{
-		Limit: 2,
-		Page:  1,
-	})
-	s.Require().NoError(err)
-
-	var resp2 []Role
-	err = s.client.ExecRequestPaged(&Request{
-		Method:    MethodGet,
-		Path:      PathRoles,
-		RespModel: &resp2,
-	}, &Page{
-		Limit: 1,
-		Page:  2,
-	})
-	s.Require().NoError(err)
-
-	s.Require().Equal(2, len(resp1))
-	s.Require().Equal(1, len(resp2))
-
-	s.Equal(resp1[1].ID, resp2[0].ID)
+	authResponder, err = httpmock.NewJsonResponder(401, authResponse)
+	require.NoError(t, err)
+	httpmock.Deactivate()
+	httpmock.Activate()
+	httpmock.RegisterResponder(http.MethodPost, "https://test_subdomain.onelogin.com/auth/oauth2/v2/token", authResponder)
+	_, err = c.authRequest(ctx)
+	assert.Error(t, err)
 }

--- a/onelogin/client_test.go
+++ b/onelogin/client_test.go
@@ -25,8 +25,6 @@ type clientTestSuite struct {
 	subdomain    string
 
 	client *Client
-
-	ctx context.Context
 }
 
 func TestRunClientTestSuite(t *testing.T) {
@@ -162,7 +160,8 @@ func (s *clientTestSuite) Test_Retries() {
 	request.Context = context.Background()
 	request.RetryWait = time.Millisecond * 100
 	request.RetryBackoffFactor = 0
-	s.client.ExecRequest(request)
+	err = s.client.ExecRequest(request)
+	s.Error(err)
 	s.Require().Equal(4, timesCalled)
 	timeBetween := []time.Duration{
 		timeCalled[1].Sub(timeCalled[0]),
@@ -188,7 +187,8 @@ func (s *clientTestSuite) Test_Retries() {
 	request.Context = context.Background()
 	request.RetryWait = time.Millisecond * 100
 	request.RetryBackoffFactor = 1
-	s.client.ExecRequest(request)
+	err = s.client.ExecRequest(request)
+	s.Error(err)
 	s.Require().Equal(4, timesCalled)
 	timeBetween = []time.Duration{
 		timeCalled[1].Sub(timeCalled[0]),


### PR DESCRIPTION
- Add retries to OneLogin client ExecRequest
- Add retries for commonly returned status codes for any mapping operation that affects position/order
- Update mapping order create to set the mapping order upon resource creation
- Add load tests for deleting a large number of mappings

Fixes #35 